### PR TITLE
only use -f command line flag for necessary versions

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -65,9 +65,12 @@ Cluster.prototype.initalizeNodes = function (path) {
 
   this.nodes = _.map(nodes, function (config) {
     var options = {
+      version: self.options.version,
+      branch: self.options.branch,
       config: config,
       path: path
     };
+
     if (self.options.clusterNameOverride) {
       options.clusterNameOverride = self.options.clusterNameOverride;
     }

--- a/lib/node.js
+++ b/lib/node.js
@@ -11,6 +11,7 @@ var writeTempConfig = require('./writeTempConfig');
 
 var Node = module.exports = function Node (options) {
   this.version = options.version;
+  this.branch = options.branch;
   this.path = options.path;
   this.config = options.config;
   this.clusterNameOverride = options.clusterNameOverride;
@@ -22,7 +23,13 @@ Node.prototype.start = function (cb) {
   var self = this;
   return writeTempConfig(self.config).then(function (configPath) {
     return new Promises(function (resolve, reject) {
-      var args = ['-f', '-D', 'es.config='+configPath];
+      var args = ['-D', 'es.config='+configPath];
+
+      // branch names aren't valid semver, just check the first number
+      var majorVersion = (self.version || self.branch).split('.').shift();
+      if (majorVersion === '0') {
+        args.unshift('-f');
+      }
 
       if (self.clusterNameOverride) {
         args.push('-D');


### PR DESCRIPTION
Starting in 1.0, `bin/elasticsearch` starts in the foreground by default. Apparently starting in 1.4.x specifying the `-f` flag causes `bin/elasticsearch` to fail with "getopt: illegal option -- f"