### PR TITLE
parse lines one at a time, handle unformatted log4j lines

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,5 @@
+{
+  "node": true,
+  "undef": true,
+  "boss": true
+}

--- a/lib/node.js
+++ b/lib/node.js
@@ -7,6 +7,8 @@ var utils = require('./utils');
 var join = require('path').join;
 var semver = require('semver');
 var moment = require('moment');
+var split = require('split');
+var through2 = require('through2');
 var writeTempConfig = require('./writeTempConfig');
 
 var Node = module.exports = function Node (options) {
@@ -42,43 +44,83 @@ Node.prototype.start = function (cb) {
       // run the process
       self.process = spawn(path, args);
 
-      var parseLog = _.bindKey(self, 'parseLog');
-      self.process.stderr.on('data', _.partial(parseLog, 'stderr'));
-      self.process.stdout.on('data', _.partial(parseLog, 'stdout'));
+      self.process.stdout
+      .pipe(split())
+      .pipe(self.logLineParser('stdout'));
+
+      self.process.stderr
+      .pipe(split())
+      .pipe(self.logLineParser('stderr'));
+
       self.process.once('error', reject);
       self.once('start', resolve);
     });
   }).nodeify(cb);
 };
 
-Node.prototype.parseLog = function (level, data) {
-  var message = data.toString('utf8');
-  var matches = message.match(/^\[([^\]]+)\]\[([^\]]+)\]\[([^\]]+)\]\s*\[([^\]]+)\](.+)/);
-  if (matches) {
-    var msgObj = {
+Node.prototype.logLineParser = function (stream) {
+  var self = this;
+  return through2(function (line, enc, cb) {
+    cb();
+
+    var message = line.toString('utf8').trim();
+    if (!message) return;
+    self.parseLog(stream, message);
+  });
+};
+
+Node.prototype.parseLog = function (stream, message) {
+  var msgObj = this.parseLine(stream, message);
+
+  if (!msgObj) {
+    this.emit('error', new Error('malformed log message: ' + JSON.stringify(message)));
+    return;
+  }
+
+  if (msgObj.type === 'node' && msgObj.message === 'started') {
+    this.emit('start', this);
+    this.name = msgObj.node;
+  }
+
+  if (msgObj.type === 'http' && /bound_address/.test(msgObj.message)) {
+    this.parsePort(msgObj.message);
+  }
+
+  this.emit('log', msgObj);
+};
+
+Node.prototype.parseLine = function (stream, line) {
+  var matches;
+
+  if (matches = line.match(/^\[([^\]]+)\]\[([^\]]+)\]\[([^\]]+)\]\s*\[([^\]]+)\](.+)/)) {
+    return {
       timestamp: moment(matches[1].trim(), 'YYYY-MM-DD HH:mm:ss,SSS').toDate(),
       level: matches[2].trim(),
       type: matches[3].trim(),
       node: matches[4].trim(),
       message: matches[5].trim()
     };
-
-    if (msgObj.type === 'node' && msgObj.message === 'started') {
-      this.emit('start', this);
-      this.name = msgObj.node;
-    }
-
-    if (msgObj.type === 'http' && /bound_address/.test(msgObj.message)) {
-      this.parsePort(msgObj.message);
-    }
-
-    this.emit('log', msgObj);
   }
 
-  if (level === 'stderr') {
-    var errorMessage = data.toString('utf8').trim();
-    if (errorMessage) this.emit('error', new Error(errorMessage));
+  if (matches = line.match(/^log4j:([A-Z]+)([^\n]+)$/)) {
+    return {
+      timestamp: moment().toDate(),
+      level: matches[1].trim(),
+      type: 'log4j',
+      node: '?',
+      message: matches[2].trim()
+    };
   }
+
+  if (stream === 'stderr') return;
+
+  return {
+    timestamp: moment().toDate(),
+    level: 'INFO',
+    type: '?',
+    node: '?',
+    message: line
+  };
 };
 
 Node.prototype.parsePort = function (message) {

--- a/package.json
+++ b/package.json
@@ -30,8 +30,10 @@
     "request": "~2.36.0",
     "rimraf": "~2.2.8",
     "semver": "~2.3.0",
+    "split": "~0.3.2",
     "tar": "~0.1.19",
-    "temp": "^0.8.0"
+    "temp": "^0.8.0",
+    "through2": "~0.6.3"
   },
   "devDependencies": {
     "chai": "~1.9.1",


### PR DESCRIPTION
While running 1.4.2 on travis, log4j started logging `log4j:WARN No appenders could be found for logger (common)`.

This wasn't parseable by libesvm, and came on stderr, so it rejected the promise for `cluster.start()` and made things fall apart.

This adds handlers for this format of message, and also uses the `split()` module to ensure that parsing only happens on a per line basis (the log4j messages came two lines per chunk).