### PR TITLE
Fix temp config creation

### DIFF
--- a/lib/resolveVersion.js
+++ b/lib/resolveVersion.js
@@ -2,6 +2,15 @@ var _ = require('lodash');
 var fetchAllTags = require('./fetchAllTags');
 var semver = require('semver');
 
+// match valid tag names and extract that parts that we want semver to consider
+var TAG_PARTS_RE = /^v?(\d+\.\d+\.\d+)(?:\.([a-zA-Z0-9_\-]+))?$/;
+
+function mapTagToSemver(version) {
+  var matches = version.match(TAG_PARTS_RE);
+  if (!matches) return undefined;
+  return matches[1] + (matches[2] ? '-' + matches[2] : '');
+}
+
 /**
  * Resolve the latest version
  * @param {string} version A semver string
@@ -10,25 +19,23 @@ var semver = require('semver');
  */
 module.exports = function (options, cb) {
   return fetchAllTags().then(function (tags) {
-    tags = _.map(tags, function (tag) {
-      if (tag.name) tag.name = tag.name.replace(/\.(beta|rc)/i, '-$1');
-      return tag;
+    var versions = _(tags).pluck('name').map(String).invoke('trim').value();
+    var validVersions = versions.map(mapTagToSemver).filter(Boolean).sort(semver.rcompare);
+    var version = _.find(validVersions, function (tag) {
+      return semver.satisfies(tag, options.version);
     });
-    tags.sort(function (v1, v2) {
-      return semver.gt(v1.name, v2.name);
-    }).reverse();
-    var length = tags.length;
-    for (var i = 0; i<length; i++) {
-      if (!tags[i].name) continue;
-      var matches = tags[i].name.match(/^v(\d+\.\d+\.\d+)(\.(.+))?/);
-      var name = matches[1];
-      if (matches[3]) name += '-' + matches[3];
-      if (semver.satisfies(name, options.version)) {
-        return tags[i].name.replace('v', '');
-      }
+
+    if (version) return version;
+
+    var error = 'Unable to find a version for "' + options.version + '"';
+    var invalidVersions = _.difference(versions, validVersions);
+    if (validVersions.length) {
+      error += ' in "' + validVersions.join('", "') + '"';
+    }
+    if (invalidVersions.length) {
+      error += ' with invalid versions "' + invalidVersions.join('", "') + '"';
     }
 
-    throw new Error('A suitable version was not found.');
+    throw new Error(error);
   });
 };
-

--- a/lib/writeTempConfig.js
+++ b/lib/writeTempConfig.js
@@ -1,19 +1,17 @@
 var temp = require('temp');
 var fs = require('fs');
-var Promises = require('bluebird');
-temp.track();
+var writeFile = require('bluebird').promisify(fs.writeFile);
 
-module.exports = function (config, cb) {
-  return new Promises(function (resolve, reject) {
-    var options = { prefix: 'libesvm-', suffix: '.json' };
-    temp.open(options, function (err, info) {
-      fs.write(info.fd, JSON.stringify(config), function (err) {
-        if (err) return reject(err);
-        fs.close(info.fd, function (err) {
-          if (err) return reject(err);
-          resolve(info.path);
-        });
-      });
-    });
-  }).nodeify(cb);
+var trash = [];
+process.on('exit', function () {
+  trash.forEach(function (p) {
+    fs.unlinkSync(p);
+  });
+});
+
+module.exports = function (config) {
+  var path = temp.path({ prefix: 'libesvm-', suffix: '.json' });
+  trash.push(path);
+
+  return writeFile(path, JSON.stringify(config), 'utf8').thenReturn(path);
 };


### PR DESCRIPTION
Fixed a regression in the writeTempConfig.js lib related to the difference between 0.10 and 0.12 file descriptors and added a bunch of debug info to the resolveVersion "unable to resolve" error.