### PR TITLE
Windows fixes

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -38,7 +38,9 @@ Node.prototype.start = function (cb) {
       }
 
       // the path of the executable
-      var path = join(self.path, 'bin', 'elasticsearch');
+      var isWindows = /^win/.test(process.platform);
+      var file = 'elasticsearch' + (isWindows ? '.bat' : '');
+      var path = join(self.path, 'bin', file);
 
       // run the process
       self.process = spawn(path, args);

--- a/lib/node.js
+++ b/lib/node.js
@@ -25,7 +25,7 @@ Node.prototype.start = function (cb) {
   var self = this;
   return writeTempConfig(self.config).then(function (configPath) {
     return new Promises(function (resolve, reject) {
-      var args = ['-D', 'es.config='+configPath];
+      var args = ['-Des.config='+configPath];
 
       // branch names aren't valid semver, just check the first number
       var majorVersion = (self.version || self.branch).split('.').shift();
@@ -34,8 +34,7 @@ Node.prototype.start = function (cb) {
       }
 
       if (self.clusterNameOverride) {
-        args.push('-D');
-        args.push('es.cluster.name='+self.clusterNameOverride);
+        args.push('-Des.cluster.name='+self.clusterNameOverride);
       }
 
       // the path of the executable


### PR DESCRIPTION
1) Run elasticsearch.bat
2) Remove spaces when setting system properties.  This was causing the "Error:  Could not find or load main class es.config=..."