### PR TITLE
Move moment from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "bluebird": "~2.1.2",
     "lodash": "~2.4.1",
     "mkdirp": "~0.5.0",
+    "moment": "^2.7.0",
     "properties-parser": "^0.2.3",
     "request": "~2.36.0",
     "rimraf": "~2.2.8",
@@ -40,7 +41,6 @@
     "cli-color": "^0.3.2",
     "connect": "^3.3.5",
     "mocha": "*",
-    "moment": "^2.7.0",
     "progress": "^1.1.7",
     "sinon": "^1.14.1"
   }


### PR DESCRIPTION
The moment dependency is required for running, so moved it to dependencies.