### PR TITLE
Stop elasticsearch process on Windows

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -10,6 +10,7 @@ var moment = require('moment');
 var split = require('split');
 var through2 = require('through2');
 var writeTempConfig = require('./writeTempConfig');
+var isWindows = /^win/.test(process.platform);
 
 var Node = module.exports = function Node (options) {
   this.version = options.version;
@@ -38,7 +39,6 @@ Node.prototype.start = function (cb) {
       }
 
       // the path of the executable
-      var isWindows = /^win/.test(process.platform);
       var file = 'elasticsearch' + (isWindows ? '.bat' : '');
       var path = join(self.path, 'bin', file);
 
@@ -140,6 +140,10 @@ Node.prototype.shutdown = function (cb) {
   var self = this;
   return new Promises(function (resolve, reject) {
     self.process.on('close', resolve);
-    self.process.kill('SIGINT');
+    if (isWindows) {
+      spawn('taskkill', ['/pid', self.process.pid, '/F', '/T']);
+    } else {
+      self.process.kill('SIGINT');
+    }
   }).nodeify(cb);
 };


### PR DESCRIPTION
On Windows the elasticsearch instance was not closed after running grunt-esvm.  This uses taskkill to close the process tree starting from elasticsearch.bat.