### PR TITLE
Use path.conf property instead of config

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -24,9 +24,9 @@ Node.prototype = _.create(EventEmitter.prototype, { constructor: Node });
 
 Node.prototype.start = function (cb) {
   var self = this;
-  return writeTempConfig(self.config).then(function (configPath) {
+  return writeTempConfig(self.config, self.path).then(function (configPath) {
     return new Promises(function (resolve, reject) {
-      var args = ['-Des.config='+configPath];
+      var args = ['-Des.path.conf='+configPath];
 
       // branch names aren't valid semver, just check the first number
       var majorVersion = (self.version || self.branch).split('.').shift();

--- a/lib/writeTempConfig.js
+++ b/lib/writeTempConfig.js
@@ -1,17 +1,32 @@
 var temp = require('temp');
 var fs = require('fs');
-var writeFile = require('bluebird').promisify(fs.writeFile);
+var rimraf = require('rimraf');
+var fsExtra = require('fs-extra');
+var path = require('path');
+var Promise = require('bluebird');
 
-var trash = [];
+var writeFile = Promise.promisify(fs.writeFile);
+var mkdirTemp = Promise.promisify(temp.mkdir);
+var copy = Promise.promisify(fsExtra.copy);
+
+var tempConfigFolder;
 process.on('exit', function () {
-  trash.forEach(function (p) {
-    fs.unlinkSync(p);
-  });
+  if (tempConfigFolder) {
+    rimraf.sync(tempConfigFolder);
+  }
 });
 
-module.exports = function (config) {
-  var path = temp.path({ prefix: 'libesvm-', suffix: '.json' });
-  trash.push(path);
+module.exports = function (config, esPath) {
+  return mkdirTemp({prefix: 'libesvm-'}).then(function createConfig(dir) {
+    tempConfigFolder = dir;
 
-  return writeFile(path, JSON.stringify(config), 'utf8').thenReturn(path);
+    var configFileDestination = path.join(dir, 'elasticsearch.json');
+    var loggingFileDestination = path.join(dir, 'logging.yml');
+    var loggingFileSource = path.join(esPath, 'config/logging.yml');
+
+    return Promise.all([
+        writeFile(configFileDestination, JSON.stringify(config), 'utf8'),
+        copy(loggingFileSource, loggingFileDestination)
+      ]).thenReturn(dir);
+  });
 };

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/ccowan/libesvm",
   "dependencies": {
     "bluebird": "~2.1.2",
+    "fs-extra": "^0.24.0",
     "lodash": "~2.4.1",
     "mkdirp": "~0.5.0",
     "moment": "^2.7.0",

--- a/test/writeTempConfig.js
+++ b/test/writeTempConfig.js
@@ -1,0 +1,60 @@
+var expect = require('chai').expect;
+var _ = require('lodash');
+var writeTempConfig = require('../lib/writeTempConfig');
+var Promise = require('bluebird');
+var fs = Promise.promisifyAll(require('fs'));
+var temp = Promise.promisifyAll(require('temp'));
+var join = require('path').join;
+
+temp.track();
+
+function writeMockConfig(done) {
+  temp.mkdirAsync('mockFiles').then(function(dir) {
+    return fs.mkdirAsync(join(dir, 'config')).then(function() {
+      var tempFiles = ['elasticsearch.json', 'logging.yml'];
+      return Promise.all(tempFiles.map(function(file) {
+        return fs.writeFileAsync(join(dir, 'config', file), '');
+      }));
+    }).then(function() {
+      done(dir);
+    });
+  });
+}
+
+function removeMockConfig(done) {
+  temp.cleanupAsync().then(function(stats) {
+    done();
+  });
+}
+
+describe('write temp config', function () {
+  var mockConfigFolder;
+  beforeEach(function(done) {
+    writeMockConfig(function(dir) {
+      mockConfigFolder = dir;
+      done();
+    });
+  });
+
+  it('should create a temp folder with configs', function(done) {
+    writeTempConfig({foo: 'bar'}, mockConfigFolder).then(function(path) {
+      return fs.readdirAsync(path);
+    }).then(function(files) {
+      expect(files.indexOf('elasticsearch.json')).to.be.above(-1);
+      expect(files.indexOf('logging.yml')).to.be.above(-1);
+      done();
+    });
+  });
+
+  afterEach(function(done) {
+    removeMockConfig(function() {
+      fs.readdirAsync(mockConfigFolder).then(function(files) {
+        throw new Error('mock config should be cleaned up');
+      }, function(err) {
+        expect(err.cause.code).to.equal('ENOENT');
+        done();
+      });
+    });
+  });
+});
+


### PR DESCRIPTION
es.config is no longer supported, this switches to using es.path.conf.  

Instead of making a temp config, we create a temp directory with the config written to elasticsearch.json, and the default logging.yml copied over.

Closes #18.