### PR TITLE
Make installFromBranch work again

### DIFF
--- a/lib/installFromBranch.js
+++ b/lib/installFromBranch.js
@@ -1,4 +1,5 @@
 var downloadAndInstall = require('./downloadAndInstall');
+var fetchAllTags = require('./fetchAllTags');
 var _ = require('lodash');
 
 
@@ -16,6 +17,8 @@ module.exports = function (options, cb) {
   return fetchAllTags()
   .then(function (tags) {
     if (!tags.branches[branch]) {
+      // version numbers are 0-9, 0-9X, or MASTER
+      var key = 'URL_' + branch.replace(/[\._]+/g, '').toUpperCase();
       throw new Error('Branch ' + branch + ' is not available for install. (' + key + ')');
     }
     var url = tags.branches[branch].tarball;


### PR DESCRIPTION
63a898c315 broke installing from branch.

This fixes it.

- Added require for `fetchAllTags`
- Brought back the key parsing in the error message