### PR TITLE
Handle invalid plugin failures

### DIFF
--- a/lib/installPlugin.js
+++ b/lib/installPlugin.js
@@ -35,31 +35,32 @@ module.exports = function (options, cb) {
   var plugin = options.plugin;
   var pluginName = (_.isPlainObject(plugin) ? plugin.name : plugin);
 
+  function handleInstallError(resolve, reject, stdout, fn) {
+    var errorCause = getErrorCause(stdout);
+    if (errorCause === ERR_DOWNLOAD_FAILED) {
+      var msg = 'Failed to download plugin: ' + pluginName + '\n' + stdout;
+      return reject(new Error(msg));
+    }
+    if (errorCause === ERR_ALREADY_EXISTS) return resolve(true);
+
+    fn.call(fn);
+  }
+
   log('INFO', 'Installing "'+ pluginName + '" plugin');
   return new Promises(function (resolve, reject) {
     exec(installCommand(path, plugin), function (err, stdout) {
       if (!err) return resolve(stdout);
 
-      var errorCause = getErrorCause(stdout);
-      if (errorCause === ERR_DOWNLOAD_FAILED) {
-        var msg = 'Failed to download plugin: ' + pluginName + '\n' + stdout;
-        return reject(new Error(msg));
-      }
-      if (errorCause === ERR_ALREADY_EXISTS) return resolve(true);
+      handleInstallError(resolve, reject, stdout, function () {
+        exec(installCommand(path, plugin, true), function (err, stdout) {
+          if (!err) return resolve (stdout);
 
-      exec(installCommand(path, plugin, true), function (err, stdout) {
-        if (!err) return resolve (stdout)
-
-        var errorCause = getErrorCause(stdout);
-        if (errorCause === ERR_DOWNLOAD_FAILED) {
-          var msg = 'Failed to download plugin: ' + pluginName + '\n' + stdout;
-          return reject(new Error(msg));
-        }
-        if (errorCause === ERR_ALREADY_EXISTS) return resolve(true);
-
-        // TODO: should probably handle other errors
-        resolve(true);
-      })
+          handleInstallError(resolve, reject, stdout, function () {
+            // TODO: should probably handle other errors
+            resolve(true);
+          });
+        });
+      });
     });
   })
   .nodeify(cb);

--- a/lib/installPlugin.js
+++ b/lib/installPlugin.js
@@ -5,6 +5,9 @@ var exec          = Promises.promisify(child_process.exec);
 var semver        = require('semver');
 var join          = require('path').join;
 
+var ERR_UNKNOWN_COMMAND = 64;
+var ERR_INVALID_PLUGIN = 74;
+
 function oldInstall(path, plugin) {
   var cmd = join(path, 'bin', 'plugin');
   if (_.isPlainObject(plugin)) {
@@ -35,16 +38,24 @@ function newInstall(path, plugin) {
  */
 module.exports = function (options, cb) {
   // TODO need to find a way to check to see if the plugin is installed or not.
-	var log = options.log || _.noop;
-	var path = options.path;
-	var plugin = options.plugin;
+  var log = options.log || _.noop;
+  var path = options.path;
+  var plugin = options.plugin;
+  var pluginName = (_.isPlainObject(plugin) ? plugin.name : plugin);
 
-	log('INFO', 'Installing "'+ (_.isPlainObject(plugin) ? plugin.name : plugin) + '" plugin');
-	return exec(newInstall(path, plugin)).catch(function (err) {
-    return exec(oldInstall(path, plugin));
-  }).catch(function (err) {
-		// We need to ignore errors if the plugins already exist.
-		return true;
-	}).nodeify(cb);
+  log('INFO', 'Installing "'+ pluginName + '" plugin');
+  return exec(newInstall(path, plugin))
+  .catch(function (err) {
+    if (err.cause.code !== ERR_INVALID_PLUGIN) throw new Error('Invalid plugin: ' + pluginName);
+
+    return exec(oldInstall(path, plugin))
+    .catch(function (err) {
+      if (err.cause.code !== ERR_INVALID_PLUGIN) throw new Error('Invalid plugin: ' + pluginName);
+
+      // We need to ignore errors if the plugins already exist.
+      return true;
+    });
+  })
+  .nodeify(cb);
 };
 

--- a/lib/installPlugin.js
+++ b/lib/installPlugin.js
@@ -8,23 +8,10 @@ var join          = require('path').join;
 var ERR_UNKNOWN_COMMAND = 64;
 var ERR_INVALID_PLUGIN = 74;
 
-function oldInstall(path, plugin) {
-  var cmd = join(path, 'bin', 'plugin');
-  if (_.isPlainObject(plugin)) {
-    cmd += ' --install ' + plugin.name + ' --url ' + plugin.path;
-  } else {
-    cmd += ' --install ' + plugin;
-  }
-  return cmd;
-}
-
-function newInstall(path, plugin) {
+function installCommand(path, plugin, oldCommand) {
     var cmd = join(path, 'bin', 'plugin');
-    if (_.isPlainObject(plugin)) {
-      cmd += ' install ' + plugin.name + ' --url ' + plugin.path;
-    } else {
-      cmd += ' install ' + plugin;
-    }
+    cmd += (oldCommand === true) ? ' --install ' : ' install ';
+    cmd += (_.isPlainObject(plugin)) ? plugin.name + ' --url ' + plugin.path : plugin;
     return cmd;
 }
 
@@ -44,11 +31,11 @@ module.exports = function (options, cb) {
   var pluginName = (_.isPlainObject(plugin) ? plugin.name : plugin);
 
   log('INFO', 'Installing "'+ pluginName + '" plugin');
-  return exec(newInstall(path, plugin))
+  return exec(installCommand(path, plugin))
   .catch(function (err) {
     if (err.cause.code !== ERR_INVALID_PLUGIN) throw new Error('Invalid plugin: ' + pluginName);
 
-    return exec(oldInstall(path, plugin))
+    return exec(installCommand(path, plugin, true))
     .catch(function (err) {
       if (err.cause.code !== ERR_INVALID_PLUGIN) throw new Error('Invalid plugin: ' + pluginName);
 

--- a/lib/installPlugin.js
+++ b/lib/installPlugin.js
@@ -1,18 +1,24 @@
-var child_process = require('child_process');
 var _             = require('lodash');
 var Promises      = require('bluebird');
-var exec          = Promises.promisify(child_process.exec);
+var exec          = require('child_process').exec;
 var semver        = require('semver');
 var join          = require('path').join;
 
-var ERR_UNKNOWN_COMMAND = 64;
-var ERR_INVALID_PLUGIN = 74;
+var ERR_UNKNOWN = 0;
+var ERR_DOWNLOAD_FAILED = 1;
+var ERR_ALREADY_EXISTS = 2;
 
 function installCommand(path, plugin, oldCommand) {
     var cmd = join(path, 'bin', 'plugin');
     cmd += (oldCommand === true) ? ' --install ' : ' install ';
     cmd += (_.isPlainObject(plugin)) ? plugin.name + ' --url ' + plugin.path : plugin;
     return cmd;
+}
+
+function getErrorCause(stdout) {
+  if (stdout.match(new RegExp('failed to download', 'i'))) return ERR_DOWNLOAD_FAILED;
+  if (stdout.match(new RegExp('already exists', 'i'))) return ERR_ALREADY_EXISTS;
+  return ERR_UNKNOWN;
 }
 
 /**
@@ -24,23 +30,36 @@ function installCommand(path, plugin, oldCommand) {
  * @returns {Promises}
  */
 module.exports = function (options, cb) {
-  // TODO need to find a way to check to see if the plugin is installed or not.
   var log = options.log || _.noop;
   var path = options.path;
   var plugin = options.plugin;
   var pluginName = (_.isPlainObject(plugin) ? plugin.name : plugin);
 
   log('INFO', 'Installing "'+ pluginName + '" plugin');
-  return exec(installCommand(path, plugin))
-  .catch(function (err) {
-    if (err.cause.code !== ERR_INVALID_PLUGIN) throw new Error('Invalid plugin: ' + pluginName);
+  return new Promises(function (resolve, reject) {
+    exec(installCommand(path, plugin), function (err, stdout) {
+      if (!err) return resolve(stdout);
 
-    return exec(installCommand(path, plugin, true))
-    .catch(function (err) {
-      if (err.cause.code !== ERR_INVALID_PLUGIN) throw new Error('Invalid plugin: ' + pluginName);
+      var errorCause = getErrorCause(stdout);
+      if (errorCause === ERR_DOWNLOAD_FAILED) {
+        var msg = 'Failed to download plugin: ' + pluginName + '\n' + stdout;
+        return reject(new Error(msg));
+      }
+      if (errorCause === ERR_ALREADY_EXISTS) return resolve(true);
 
-      // We need to ignore errors if the plugins already exist.
-      return true;
+      exec(installCommand(path, plugin, true), function (err, stdout) {
+        if (!err) return resolve (stdout)
+
+        var errorCause = getErrorCause(stdout);
+        if (errorCause === ERR_DOWNLOAD_FAILED) {
+          var msg = 'Failed to download plugin: ' + pluginName + '\n' + stdout;
+          return reject(new Error(msg));
+        }
+        if (errorCause === ERR_ALREADY_EXISTS) return resolve(true);
+
+        // TODO: should probably handle other errors
+        resolve(true);
+      })
     });
   })
   .nodeify(cb);


### PR DESCRIPTION
Closes #24

- Refactor/depromisify to access `stdout`
- Parse `stdout` for error reason
- Handle download failed error
- Handle already exists failure (silently continue)

~~This adds a check for the specific error case. In both the 2.x branch and 1.7 version, the error code for an invalid plugin is 74, so this should be a reliable way to see react to that specific failure.~~

The plugin CLI uses exit code `74` for both "already exists" and "failed to download" errors. So, I de-promisified the code and parsed `stdout`, since there's really no other way to determine *why* the plugin install failed.

Also fixed some formatting - your newer code was using tabs.

![screenshot 2015-12-07 16 07 29](https://cloud.githubusercontent.com/assets/404731/11642912/ea2f7882-9cfd-11e5-9d61-906d950e1f8e.png)
**2.x** Note that license is already installed, and it continues as it should

![screenshot 2015-12-07 16 07 09](https://cloud.githubusercontent.com/assets/404731/11642925/feb5eed0-9cfd-11e5-980a-9d66b57ac087.png)
**1.7/1.x** Failures work here as well