### PR TITLE
Fix ES config overrides

### DIFF
--- a/lib/writeTempConfig.js
+++ b/lib/writeTempConfig.js
@@ -21,7 +21,12 @@ process.on('exit', function () {
 module.exports = function (config, esPath) {
   return mkdirTemp({prefix: 'libesvm-'}).then(function createConfig(dir) {
     console.log(dir);
-    return copy(join(esPath, 'config'), dir)
+    var configFileDestination = path.join(dir, 'elasticsearch.json');
+
+    return Promise.all([
+      writeFile(configFileDestination, JSON.stringify(config), 'utf8'),
+      copy(join(esPath, 'config'), dir)
+    ])
     .then(function () {
       return remove(join(dir, 'elasticsearch.yml'));
     })


### PR DESCRIPTION
Still need to create elasticsearch.json for overrides of default ES options to work. This is causing builds to fail because `grunt esvm:test` is running ES on port 9200 instead of 9210 like it should.

http://build-eu-00.elastic.co/job/kibana_core_pr/2337/console