### PR TITLE
Xpack users roles creation

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -32,7 +32,7 @@ Node.prototype.start = function (cb) {
   var self = this;
   return getActualVersion(self.path).then(function (version) {
     return writeTempConfig(self.config, self.path)
-    .then(writeShieldConfig(self.options))
+    .then(writeShieldConfig(self.options, version))
     .then(function (configPath) {
       return new Promises(function (resolve, reject) {
         self.configPath = configPath;

--- a/lib/writeShieldConfig.js
+++ b/lib/writeShieldConfig.js
@@ -13,22 +13,6 @@ var outputFile = Promise.promisify(fsExtra.outputFile);
 var hash = Promise.promisify(bcrypt.hash);
 var yaml = require('js-yaml');
 
-function copyShieldFiles(basePath, configPath) {
-  return new Promise(function (resolve, reject) {
-    glob(path.join(basePath, 'config', 'shield', '*'), function (err, files) {
-      if (err) return reject(err);
-      mkdirs(path.join(configPath, 'shield'))
-      .then(function () {
-        return Promise.each(files, function (file) {
-          var src = file;
-          var dest = path.join(configPath, 'shield', path.basename(file));
-          return copy(src, dest);
-        });
-      }).then(resolve, reject);
-    });
-  });
-}
-
 function createUsersAndRoles(configPath, users) {
   return function () {
     var userHash = {};

--- a/lib/writeShieldConfig.js
+++ b/lib/writeShieldConfig.js
@@ -5,6 +5,7 @@ var path = require('path');
 var Promise = require('bluebird');
 var fsExtra = require('fs-extra');
 var fs = require('fs');
+var semver = require('semver');
 var copy = Promise.promisify(fsExtra.copy);
 var mkdirs = Promise.promisify(fsExtra.mkdirs);
 var stat = Promise.promisify(fs.stat);
@@ -36,20 +37,20 @@ function createUsersAndRoles(configPath, users) {
       _.each(userHash, function (hash, username) {
         data.push(username + ':' + hash);
       })
-      return outputFile(path.join(configPath, 'shield', 'users'), data.join("\n"));
+      return outputFile(path.join(configPath, 'users'), data.join("\n"));
     })
     .then(function () {
       var data = [];
       _.each(roleHash, function (users, role) {
         data.push(role + ':' + users.join(','));
       })
-      return outputFile(path.join(configPath, 'shield', 'users_roles'), data.join("\n"));
+      return outputFile(path.join(configPath, 'users_roles'), data.join("\n"));
     });
   };
 }
 
 function createRoles(configPath, roles) {
-  var rolesYml = path.join(configPath, 'shield', 'roles.yml');
+  var rolesYml = path.join(configPath, 'roles.yml');
   return stat(rolesYml).then(function (arg) {
     return readFile(rolesYml, 'utf8').then(function (data) {
       var rolesConfig = yaml.safeLoad(data);
@@ -62,14 +63,18 @@ function createRoles(configPath, roles) {
   });
 }
 
-module.exports = function writeShieldConfig(options) {
+module.exports = function writeShieldConfig(options, version) {
   return function (configPath) {
+    // append the shield/xpack directory to configPath
+    var usersConfig = semver.satisfies(version, '5.x || 3.x') ? 'xpack' : 'shield';
+    var shieldConfigPath = path.join(configPath, usersConfig);
+
     if (!options.shield || !options.shield.users) return Promise.resolve(configPath);
 
-    return Promise.try(createUsersAndRoles(configPath, options.shield.users))
+    return Promise.try(createUsersAndRoles(shieldConfigPath, options.shield.users))
     .then(function (result) {
       if (options.shield.roles) {
-        return createRoles(configPath, options.shield.roles);
+        return createRoles(shieldConfigPath, options.shield.roles);
       } else {
         return result;
       }


### PR DESCRIPTION
Creating users in Elasticsearch 5.x / 3.x is different from previous versions because Shield is now an XPack feature. The config files for users are no longer `config/shield/users*` they're now `config/xpack/users*`