### PR TITLE
Fix passing arguments to bin/elasticsearch for master

### DIFF
--- a/lib/featureDetection.js
+++ b/lib/featureDetection.js
@@ -1,0 +1,43 @@
+var Bluebird = require('bluebird');
+var join = require('path').join;
+var exec = Bluebird.promisify(require('child_process').exec);
+var memoize = require('lodash').memoize;
+
+function getVersionFlag(stdout) {
+  // versions 5.0+
+  if(/-V\b/g.test(stdout)){
+    return '-V';
+  }
+
+  // versions <2.0
+  if(/-v\b/g.test(stdout)){
+    return '-v';
+  }
+
+  // Some 2.0 version don't have --version in the help command so we can just
+  // try to assume that it will work. All the 1.x have -v
+  return '--version';
+}
+
+function getConfigVarFlag(stdout) {
+  if (stdout.indexOf('-E <KeyValuePair>') > -1) {
+    return '-Ees.';
+  }
+
+  return '-Des.';
+}
+
+exports.getFeatures = memoize(function featureDetect(path) {
+  var cmd = join(path, 'bin', 'elasticsearch');
+
+  return exec(cmd + ' --help')
+  .then(function (results) {
+    var stdout = results[0];
+    var stderr = results[1];
+
+    return {
+      versionFlag: getVersionFlag(stdout, stderr),
+      configVarFlag: getConfigVarFlag(stdout, stderr)
+    };
+  });
+});

--- a/lib/getActualVersion.js
+++ b/lib/getActualVersion.js
@@ -1,31 +1,9 @@
-var _       = require('lodash');
-var Promise = require('bluebird');
-var exec    = Promise.promisify(require('child_process').exec);
-var join    = require('path').join;
+var _           = require('lodash');
+var Promise     = require('bluebird');
+var exec        = Promise.promisify(require('child_process').exec);
+var join        = require('path').join;
+var getFeatures = require('./featureDetection').getFeatures;
 var version;
-
-function versionCommand(path) {
-  var cmd = join(path, 'bin', 'elasticsearch');
-  return exec(cmd + ' --help')
-  .then(function (results) {
-    var stdout = results[0];
-    var stderr = results[1];
-
-    // versions 5.0+
-    if(/-V\b/g.test(stdout)){
-      return cmd + ' -V';
-    }
-
-    // versions <2.0
-    if(/-v\b/g.test(stdout)){
-      return cmd + ' -v';
-    }
-
-    // Some 2.0 version don't have --version in the help command so we can just
-    // try to assume that it will work. All the 1.x have -v
-    return cmd + ' --version';
-  });
-}
 
 function parseStdOut(results) {
   var stdout = results[0];
@@ -39,14 +17,17 @@ function parseStdOut(results) {
 
 module.exports = function (path) {
   if (version) return Promise.resolve(version);
-  return versionCommand(path)
+  return getFeatures(path)
+  .then(function (features) {
+    return join(path, 'bin', 'elasticsearch') + ' ' + features.versionFlag;
+  })
   .then(function (cmd) {
     return exec(cmd).then(parseStdOut);
   }).catch(function (err) {
     var message = ("Unable to get actual version:\n" + err.message).split('\n')
       .map(function (line) {
-        return '  ' + line
+        return '  ' + line;
       }).join('\n');
     throw new Error(message);
   });
-}
+};

--- a/lib/installPlugin.js
+++ b/lib/installPlugin.js
@@ -1,46 +1,47 @@
 var _                     = require('lodash');
-var Promises              = require('bluebird');
+var Bluebird              = require('bluebird');
 var exec                  = require('child_process').exec;
 var semver                = require('semver');
 var join                  = require('path').join;
 var installSnapshotPlugin = require('./installSnapshotPlugin');
 var getActualVersion      = require('./getActualVersion');
+var getFeatures           = require('./featureDetection').getFeatures;
 
 var ERR_UNKNOWN = 0;
 var ERR_DOWNLOAD_FAILED = 1;
 var ERR_ALREADY_EXISTS = 2;
 
-function createLegacyPluginInstallCommand(path, plugin) {
+function createLegacyPluginInstallCommand(path, plugin, features) {
   var cmd = join(path, 'bin', 'plugin');
   cmd += ' --install ';
   if (_.isPlainObject(plugin)) {
     cmd += plugin.name;
     if (plugin.path) cmd += ' --url ' + plugin.path;
-    if (plugin.staging) cmd += ' -Des.plugins.staging=true';
+    if (plugin.staging) cmd += ' ' + features.configVarFlag + 'features.es.plugins.staging=true';
   } else {
     cmd += plugin;
   }
   return cmd;
 }
 
-function create2xPluginInstallCommand(path, plugin) {
+function create2xPluginInstallCommand(path, plugin, features) {
   var cmd = join(path, 'bin', 'plugin');
   cmd += ' install ';
   if (_.isPlainObject(plugin)) {
     cmd += (plugin.path) ? plugin.path : plugin.name;
-    if (plugin.staging) cmd += ' -Des.plugins.staging=true';
+    if (plugin.staging) cmd += ' ' + features.configVarFlag + 'plugins.staging=true';
   } else {
     cmd += plugin;
   }
   return cmd;
 }
 
-function create5xPluginInstallCommand(path, plugin) {
+function create5xPluginInstallCommand(path, plugin, features) {
   var cmd = join(path, 'bin', 'elasticsearch-plugin');
   cmd += ' install ';
   if (_.isPlainObject(plugin)) {
     cmd += (plugin.path) ? plugin.path : plugin.name;
-    if (plugin.staging) cmd += ' -Des.plugins.staging=true';
+    if (plugin.staging) cmd += ' ' + features.configVarFlag + 'plugins.staging=true';
   } else {
     cmd += plugin;
   }
@@ -49,18 +50,25 @@ function create5xPluginInstallCommand(path, plugin) {
 
 
 function installCommand(path, plugin) {
-  return getActualVersion(path).then(function (version) {
+  return Bluebird.all([
+    getFeatures(path),
+    getActualVersion(path),
+  ])
+  .spread(function (features, version) {
+
     if (semver.satisfies(version, '<=1.x')) {
-      return createLegacyPluginInstallCommand(path, plugin);
+      return createLegacyPluginInstallCommand(path, plugin, features);
     }
 
     if (semver.satisfies(version, '2.x')) {
-      return create2xPluginInstallCommand(path, plugin);
+      return create2xPluginInstallCommand(path, plugin, features);
     }
 
     if (semver.satisfies(version, '5.x || 3.x')) {
-      return create5xPluginInstallCommand(path, plugin);
+      return create5xPluginInstallCommand(path, plugin, features);
     }
+
+    throw new Error('Not sure how to install plugins for version ' + version);
   });
 }
 
@@ -76,7 +84,7 @@ function getErrorCause(stdout) {
  * @param {string} options.path The path of the install
  * @param {mixed} options.plugin The plugin uri or an object with name and path to binary.
  * @param {function} [options.log] The logger
- * @returns {Promises}
+ * @returns {Promise}
  */
 module.exports = function installPlugin(options, cb) {
   var log = options.log || _.noop;
@@ -99,7 +107,7 @@ module.exports = function installPlugin(options, cb) {
 
   log('INFO', 'Installing "'+ pluginName + '" plugin');
   return installCommand(path, plugin).then(function (cmd) {
-    return new Promises(function (resolve, reject) {
+    return new Bluebird(function (resolve, reject) {
       exec(cmd, function (err, stdout) {
         if (!err) return resolve(stdout);
         handleInstallError(resolve, reject, stdout, function () {
@@ -110,4 +118,3 @@ module.exports = function installPlugin(options, cb) {
     })
   }).nodeify(cb);
 };
-

--- a/lib/node.js
+++ b/lib/node.js
@@ -2,7 +2,7 @@ var child_process = require('child_process');
 var spawn = child_process.spawn;
 var EventEmitter = require('events').EventEmitter;
 var _ = require('lodash');
-var Promises = require('bluebird');
+var Bluebird = require('bluebird');
 var utils = require('./utils');
 var join = require('path').join;
 var semver = require('semver');
@@ -13,6 +13,7 @@ var writeTempConfig = require('./writeTempConfig');
 var writeShieldConfig = require('./writeShieldConfig');
 var isWindows = /^win/.test(process.platform);
 var getActualVersion = require('./getActualVersion');
+var getFeatures = require('./featureDetection').getFeatures;
 
 var startOfStackTraceRE = /^Exception in thread /;
 var continueOfStackTraceRE = /^\s*(at |Refer to the log for complete error details)/;
@@ -30,13 +31,17 @@ Node.prototype = _.create(EventEmitter.prototype, { constructor: Node });
 
 Node.prototype.start = function (cb) {
   var self = this;
-  return getActualVersion(self.path).then(function (version) {
+  return Bluebird.all([
+    getActualVersion(self.path),
+    getFeatures(self.path),
+  ])
+  .spread(function (version, features) {
     return writeTempConfig(self.config, self.path)
     .then(writeShieldConfig(self.options, version))
     .then(function (configPath) {
-      return new Promises(function (resolve, reject) {
+      return new Bluebird(function (resolve, reject) {
         self.configPath = configPath;
-        var args = ['-Des.path.conf='+configPath];
+        var args = [features.configVarFlag + 'path.conf='+configPath];
 
         // branch names aren't valid semver, just check the first number
         var majorVersion = version.split('.').shift();
@@ -45,7 +50,7 @@ Node.prototype.start = function (cb) {
         }
 
         if (self.clusterNameOverride) {
-          args.push('-Des.cluster.name='+self.clusterNameOverride);
+          args.push(features.configVarFlag + 'cluster.name='+self.clusterNameOverride);
         }
 
         // the path of the executable
@@ -194,7 +199,7 @@ Node.prototype.parsePort = function (message) {
 
 Node.prototype.shutdown = function (cb) {
   var self = this;
-  return new Promises(function (resolve, reject) {
+  return new Bluebird(function (resolve, reject) {
     if (!self.process) return;
     self.process.on('close', resolve);
     if (isWindows) {


### PR DESCRIPTION
Master no longer accept the `-Des.` flag.

To fix this I added a `featureDetection` module, which checks out the `bin/elasticsearch` executable at a specific path and tries to figure out how it works. For master this means that we look for "-E <KeyValuePair>" in the `--help` output.

This module also does the check for the version flag and memoizes the results.